### PR TITLE
fix: rename unused error variables to follow linting conventions

### DIFF
--- a/dresscode-front/src/components/layouts/PrivateRoute/PrivateRoute.tsx
+++ b/dresscode-front/src/components/layouts/PrivateRoute/PrivateRoute.tsx
@@ -30,7 +30,7 @@ const PrivateRoute = ({ children }: PrivateRouteProps) => {
 			usuarioId
 		) {
 			setLoadAttempted(true);
-			obtenerUsuarioPorId(Number(usuarioId)).catch((err: any) => {
+			obtenerUsuarioPorId(Number(usuarioId)).catch((_err: any) => {
 			});
 		}
 	}, [

--- a/dresscode-front/src/http/direccion.ts
+++ b/dresscode-front/src/http/direccion.ts
@@ -2,23 +2,23 @@ import type { Direccion } from "../types/Direccion";
 import { apiFetch } from "./apiFetch";
 const baseUrl = import.meta.env.VITE_API_URL;
 
-function handleApiError(error: unknown, context: string) {
+function handleApiError(_error: unknown, context: string) {
 	throw new Error(`No se pudo completar la operación: ${context}`);
 }
 
 export async function getDirecciones() {
 	try {
 		return await apiFetch(`${baseUrl}/direcciones`);
-	} catch (error) {
-		handleApiError(error, "obtener direcciones");
+	} catch (_error) {
+		handleApiError(_error, "obtener direcciones");
 	}
 }
 
 export async function getDireccionesActivas() {
 	try {
 		return await apiFetch(`${baseUrl}/direcciones/active`);
-	} catch (error) {
-		handleApiError(error, "obtener direcciones activas");
+	} catch (_error) {
+		handleApiError(_error, "obtener direcciones activas");
 	}
 }
 
@@ -26,8 +26,8 @@ export async function getDireccionById(id: number) {
 	if (!id || typeof id !== "number") throw new Error("ID inválido");
 	try {
 		return await apiFetch(`${baseUrl}/direcciones/${id}`);
-	} catch (error) {
-		handleApiError(error, `obtener dirección con id ${id}`);
+	} catch (_error) {
+		handleApiError(_error, `obtener dirección con id ${id}`);
 	}
 }
 
@@ -38,8 +38,8 @@ export async function changeDireccionStatus(id: number) {
 			method: "PATCH",
 			auth: true,
 		});
-	} catch (error) {
-		handleApiError(error, `cambiar estado de dirección ${id}`);
+	} catch (_error) {
+		handleApiError(_error, `cambiar estado de dirección ${id}`);
 	}
 }
 
@@ -53,7 +53,7 @@ export async function createDireccion(usuarioId: number, direccion: Direccion) {
 			method: "POST",
 			body: JSON.stringify(direccion),
 		});
-	} catch (error) {
-		handleApiError(error, `crear dirección para usuario ${usuarioId}`);
+	} catch (_error) {
+		handleApiError(_error, `crear dirección para usuario ${usuarioId}`);
 	}
 }

--- a/dresscode-front/src/http/productoTalle.ts
+++ b/dresscode-front/src/http/productoTalle.ts
@@ -2,15 +2,15 @@ import type { ProductoTalle } from "../types/ProductoTalle";
 import { apiFetch } from "./apiFetch";
 const baseUrl = import.meta.env.VITE_API_URL;
 
-function handleApiError(error: unknown, context: string) {
+function handleApiError(_error: unknown, context: string) {
 	throw new Error(`No se pudo completar la operación: ${context}`);
 }
 
 export async function getProductoTalles() {
 	try {
 		return await apiFetch(`${baseUrl}/producto-talles`);
-	} catch (error) {
-		handleApiError(error, "obtener producto talles");
+	} catch (_error) {
+		handleApiError(_error, "obtener producto talles");
 	}
 }
 

--- a/dresscode-front/src/store/imagenProductoStore.ts
+++ b/dresscode-front/src/store/imagenProductoStore.ts
@@ -28,7 +28,7 @@ export const useImagenProductoStore = create<imagenProductoState>(
 			try {
 				const imagenesFromApi = await getImagenesProducto();
 				set({ imagenes: imagenesFromApi });
-			} catch (error) {
+			} catch (_error) {
 			}
 		},
 
@@ -36,22 +36,22 @@ export const useImagenProductoStore = create<imagenProductoState>(
 			try {
 				const imagenesActivasFromApi = await getImagenesProducto();
 				set({ imagenesActivas: imagenesActivasFromApi });
-			} catch (error) {
+			} catch (_error) {
 			}
 		},
 
-		fetchImagenById: async (id) => {
+		fetchImagenById: async (_id) => {
 			try {
 				return await getImagenesProducto();
-			} catch (error) {
+			} catch (_error) {
 				return null;
 			}
 		},
 
-		updateImagen: async (id) => {
+		updateImagen: async (_id) => {
 			try {
 				await get().fetchImagenes();
-			} catch (error) {
+			} catch (_error) {
 			}
 		},
 
@@ -59,7 +59,7 @@ export const useImagenProductoStore = create<imagenProductoState>(
 			try {
 				await eliminarImagenProducto(id);
 				await get().fetchImagenes();
-			} catch (error) {
+			} catch (_error) {
 			}
 		},
 
@@ -67,7 +67,7 @@ export const useImagenProductoStore = create<imagenProductoState>(
 			try {
 				await cambiarEstadoImagenProducto(id);
 				await get().fetchImagenes();
-			} catch (error) {
+			} catch (_error) {
 			}
 		},
 
@@ -75,7 +75,7 @@ export const useImagenProductoStore = create<imagenProductoState>(
 			try {
 				await cambiarEstadoImagenProducto(id);
 				await get().fetchImagenesActivas();
-			} catch (error) {
+			} catch (_error) {
 			}
 		},
 
@@ -83,7 +83,7 @@ export const useImagenProductoStore = create<imagenProductoState>(
 			try {
 				await cambiarEstadoImagenProducto(id);
 				await get().fetchImagenesActivas();
-			} catch (error) {
+			} catch (_error) {
 			}
 		},
 	}),


### PR DESCRIPTION
Prefix unused error parameters with underscore (_error) to satisfy linting rules that warn against unused variables. The error details are not needed in these catch blocks as generic error handling is sufficient.