### PR TITLE
fix: add missing validation for producto.id in StockModal

### DIFF
--- a/dresscode-front/src/components/admin/StockModal/StockModal.tsx
+++ b/dresscode-front/src/components/admin/StockModal/StockModal.tsx
@@ -79,6 +79,8 @@ export const StockModal: React.FC<StockModalProps> = ({
 			);
 			if (!talleCreado || !talleCreado.id)
 				throw new Error("No se pudo crear el talle");
+			if (!producto.id)
+				throw new Error("Producto ID no disponible");
 			// 2. Crear producto-talle con cantidad (esto crea la relación y asigna cantidad)
 			await createProductoTalle(producto.id, talleCreado.id, cant);
 			// 3. Refrescar productos y producto seleccionado antes de cerrar el modal


### PR DESCRIPTION
Check that producto.id exists before using it in createProductoTalle call. Prevents potential null/undefined errors when creating product-taille relationships.