### PR TITLE
refactor: remove unused imports and variables

### DIFF
--- a/dresscode-front/src/components/admin/StockModal/StockModal.tsx
+++ b/dresscode-front/src/components/admin/StockModal/StockModal.tsx
@@ -5,7 +5,6 @@ import type { ProductoTalle } from "../../../types/ProductoTalle";
 import type { Talle } from "../../../types/Talle";
 import { talleStore } from "../../../store/talleStore";
 import { useProductoTalleStore } from "../../../store/talleProductoStore";
-import { getProductoById } from "../../../http/producto";
 import { useScrollLock } from "../../../hooks/useScrollLock";
 
 interface StockModalProps {

--- a/dresscode-front/src/pages/Home/Home.tsx
+++ b/dresscode-front/src/pages/Home/Home.tsx
@@ -19,7 +19,6 @@ const Home = () => {
 	const { fetchCategoriasActivas, categoriasActivas } = useCategoriaStore();
 	const { fetchProductosActivos, fetchProductosPaged } = useProductoStore();
 	const [loading, setLoading] = useState(false);
-	const [error, setError] = useState<string | null>(null);
 	const [zapatillas, setZapatillas] = useState<any[]>([]);
 	const [remeras, setRemeras] = useState<any[]>([]);
 	const [allItems, setAllItems] = useState<any[]>([]);
@@ -92,9 +91,6 @@ const Home = () => {
 
 	if (loading) {
 		return <Loader />;
-	}
-	if (error) {
-		return <div style={{ color: "red", padding: 32 }}>{error}</div>;
 	}
 
 	return (

--- a/dresscode-front/src/pages/admin/Productos/EditarProductos/EditarProducto.tsx
+++ b/dresscode-front/src/pages/admin/Productos/EditarProductos/EditarProducto.tsx
@@ -6,7 +6,6 @@ import { useProductoStore } from "../../../../store/productoStore";
 import { useMarcaStore } from "../../../../store/marcaStore";
 import { useColorStore } from "../../../../store/colorStore";
 import type { Producto } from "../../../../types/Producto";
-import type { Marca } from "../../../../types/enums/Marca";
 
 interface FormState {
 	nombre: string;
@@ -31,7 +30,6 @@ const emptyForm: FormState = {
 export const EditarProducto: React.FC = () => {
 	const { categoriasActivas, fetchCategoriasActivas } = useCategoriaStore();
 	const {
-		productosActivos,
 		pagedProductos,
 		fetchProductosActivos,
 		fetchProductosPaged,


### PR DESCRIPTION
Remove unused Marca type import from EditarProducto that was never referenced. Remove getProductoById import from StockModal that is not used in the component. Remove unused error state from Home component that is declared but never set or used.